### PR TITLE
Fix updates for documents with multiple h1 elements

### DIFF
--- a/src/SuccessModal.ts
+++ b/src/SuccessModal.ts
@@ -4,22 +4,28 @@ import { App, Modal } from 'obsidian';
 
 export class SuccessModal extends Modal {
 	link: string;
+	message?: string;
 
-	constructor(app: App, link: string) {
+	constructor(app: App, link: string, message?: string) {
 		super(app);
 		this.link = link;
+		this.message = message;
 	}
 
 	onOpen() {
 		const { contentEl } = this;
-		//contentEl.setText(`Successfully published to ${this.link}`);
-		contentEl.createEl('span', null, (span) => {
-			span.innerText = 'Successfully published to ';
-			span.createEl('a', null, (anchor) => {
+		contentEl.createEl('h3', null, (el) => {
+			el.innerText = 'Successfully published to ';
+			el.createEl('a', null, (anchor) => {
 				anchor.href = this.link;
 				anchor.innerText = this.link;
 			});
 		});
+		if (this.message) {
+			contentEl.createEl('p', null, (el) => {
+				el.innerText = this.message;
+			});
+		}
 	}
 
 	onClose() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -144,7 +144,7 @@ export default class QuipPlugin extends Plugin {
 		try {
 			const client = new QuipAPIClient(this.settings.hostname, this.settings.token);
 			await client.updateHTMLDocument(link, html);
-			new SuccessModal(this.app, link).open();
+			new SuccessModal(this.app, link, `If your Quip document hasn't updated yet, try refreshing.`).open();
 		} catch (error) {
 			console.error("Failure invoking Quip APIs", error);
 			console.dir(error);


### PR DESCRIPTION
This fixes a specific issue where documents with multiple `<h1>` elements will have a "flash of correct content", but won't actually update to the new version.